### PR TITLE
Add capability to delete attached product images in edit page

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -56,7 +56,9 @@ class ProductsController < ApplicationController
   # PATCH/PUT /products/1 or /products/1.json
   def update
     respond_to do |format|
-      if @product.update(product_params.except(:product_variant))
+      if @product.update(product_params.except(:product_variant, :images))
+        @product.process_images(params[:product][:images])
+
         # Handle associated variants
         if product_params[:product_variant].present?
           @product.primary_variant.update(product_params[:product_variant])
@@ -77,6 +79,20 @@ class ProductsController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to products_path, status: :see_other, notice: "Product was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  def delete_image
+    @product = Product.find(params[:product_id])
+    @image = @product.images.find(params[:image_id])
+    @image_id = @image.id
+
+    @image.purge
+
+    respond_to do |format|
+      format.html { redirect_to edit_product_path(@product), notice: "Image was successfully removed." }
+      format.turbo_stream
       format.json { head :no_content }
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -29,4 +29,21 @@ class Product < ApplicationRecord
     # Assuming the first variant is the primary one
     variants.first
   end
+
+  # Custom method to process and reattach images (new and existing)
+  def process_images(image_params)
+    # Reject params that are not valid integers (i.e., convert to 0), and map to valid IDs
+    existing_image_ids = image_params.reject { |param| param.to_s.to_i == 0 }.map { |param| param.to_i }
+
+    # Filter out any uploaded images (ActionDispatch::Http::UploadedFile objects)
+    new_images = image_params.select { |param| param.is_a?(ActionDispatch::Http::UploadedFile) }
+
+    # Reattach existing image IDs as image blobs
+    existing_image_ids.each do |image_id|
+      images.attach(ActiveStorage::Blob.find(image_id)) # Attach only valid IDs
+    end
+
+    # Attach new uploaded images
+    images.attach(new_images) unless new_images.empty?
+  end
 end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,6 +1,6 @@
-<%= render partial: "layouts/error", locals: { errors: @product.errors, record: 'Product' } %>
+<%= render partial: "layouts/error", locals: { errors: product.errors, record: 'Product' } %>
 
-<%= form_with(model: @product, class: "form-product") do |form| %>
+<%= form_with(model: product, class: "form-product") do |form| %>
   <!-- Brand -->
   <div class="mb-4 animate-fade-in-up">
     <%= form.label :brand, "Brand", class: "block font-medium text-gray-700" %>
@@ -27,31 +27,50 @@
   </div>
 
   <!-- Product Images Section -->
-  <div class="mt-4">
-    <div class="flex flex-wrap gap-2 mt-2">
-      <% @product.persisted? && @product.images.each do |image| %>
-        <%= image_tag image.variant(:thumb), alt: "Product Image", class: "w-24 h-24 object-cover rounded-md border border-gray-300" %>
-      <% end %>
+  <% if product.persisted? && product.images.attached? %>
+    <div class="mt-4">
+      <p class="font-medium text-gray-700 mb-2">Existing Images:</p>
+      <div class="flex flex-wrap gap-2">
+        <% product.images.each do |image| %>
+          <div id="product-image-<%= image.id %>" class="relative group">
+            <%= image_tag image.variant(:thumb), alt: "Product Image", class: "w-24 h-24 object-cover rounded-md border border-gray-300" %>
+
+            <!-- Hidden Checkbox -->
+            <%= check_box_tag "product[remove_image_ids][]", image.id, false,
+                class: "hidden", id: "remove_image_#{image.id}" %>
+
+            <!-- Icon Label -->
+            <label for="remove_image_#{image.id}" class="absolute top-0 right-0 bg-white bg-opacity-80 rounded-bl-md px-2 py-1 text-red-600 font-bold text-sm cursor-pointer hidden group-hover:block transition hover:bg-red-100">
+              <%= link_to "🗑️", product_delete_image_path(product, image_id: image.id),
+                                data: { turbo_method: :delete, turbo_confirm: "Delete this image?" },
+                                class: "text-red-500" %>
+            </label>
+
+            <!-- Hidden field to retain image if not removed -->
+            <%= hidden_field_tag "product[images][]", image.id %>
+          </div>
+        <% end %>
+      </div>
     </div>
-  </div>
+<% end %>
+
 
   <!-- Category -->
-<div class="mb-4 animate-fade-in-up">
-  <%= form.label :category, "Category", class: "block font-medium text-gray-700 mb-1" %>
-  <%= form.select :category, product.class::CATEGORIES,
-        { prompt: "Select a Category" },
-        class: "select-field" %>
-</div>
-
+  <div class="mb-4 animate-fade-in-up">
+    <%= form.label :category, "Category", class: "block font-medium text-gray-700 mb-1" %>
+    <%= form.select :category, product.class::CATEGORIES,
+          { prompt: "Select a Category" },
+          class: "select-field" %>
+  </div>
 
   <!-- Rating -->
-<div class="mb-4 animate-fade-in-up">
-  <%= form.label :rating, "Rating", class: "block font-medium text-gray-700 mb-1" %>
-  <%= form.number_field :rating,
-        in: 1.0..5.0,
-        step: 0.5,
-        class: "input-field number-field" %>
-</div>
+  <div class="mb-4 animate-fade-in-up">
+    <%= form.label :rating, "Rating", class: "block font-medium text-gray-700 mb-1" %>
+    <%= form.number_field :rating,
+          in: 1.0..5.0,
+          step: 0.1,
+          class: "input-field number-field" %>
+  </div>
 
   <!-- Variant Fields -->
   <fieldset class="mt-6 p-4 border rounded-lg shadow-inner bg-orange-50">

--- a/app/views/products/delete_image.turbo_stream.erb
+++ b/app/views/products/delete_image.turbo_stream.erb
@@ -1,0 +1,1 @@
+<turbo-stream action="remove" target="product-image-<%= @image_id %>"></turbo-stream>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :products
+  resources :products do
+    delete "images/:image_id", to: "products#delete_image", as: :delete_image
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
Added:
 1. Capability to delete already added images in product edit page
 2. Fixed existing images removing issue when editing a product
 3. Added delete icon on top right corner of each image thumbnail

Close #15